### PR TITLE
Require Jenkins 2.414.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.65</version>
+        <version>4.86</version>
         <relativePath />
 
     </parent>
@@ -15,7 +15,7 @@
     <packaging>hpi</packaging>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <jcasc.version>1.35</jcasc.version>
     </properties>
     <name>Customizable HTML Formatter Plugin</name>
@@ -53,8 +53,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2230.v0cb_4040cde55</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2982.vdce2153031a_0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -67,9 +67,8 @@
             <artifactId>antisamy-markup-formatter</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20230618</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>json-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/io/jenkins/plugins/formatter/PolicyConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/formatter/PolicyConfigurationTest.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.formatter;
 
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlTextArea;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlTextArea;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;


### PR DESCRIPTION
## Require Jenkins 2.414.3 or newer

Fixes #6 - Bump json jar version to latest by replacing the jar file dependency on json-lib with a dependency on the [JSON API library plugin](https://plugins.jenkins.io/json-api/)

[Plugin installation statistics](https://stats.jenkins.io/pluginversions/custom-markup-formatter.html) show that 85% of all installations of the plugin are already running Jenkins 2.414.3 or newer.  Users that are already running Jenkins 2.414.3 or newer can easily upgrade to this plugin version without upgrading Jenkins core.

[SECURITY-3314](https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314) strongly suggests that the minimum Jenkins version should be 2.426.3 or newer due to the critical nature of that security issue.  However, rather than risk that this pull request might be rejected because it only covers 72% of all the installations of the plugin, I kept it at 2.414.3.

Upgrades to the most recent version of HTMLUnit so that automated tests continue to run.

Upgrades to the most recent parent pom so that the latest capabilities of the plugin parent pom are available.

### Testing done

Confirmed that automated tests pass on my Linux computer with Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
