### PR TITLE
Update owasp-java-html-sanitizer references

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Thus, each element in the JSON array represents one policy.
     
     2. **Inbuilt Policy**
     
-        Inbuilt policy is defined in the Sanitizers class available at [[GitHub](https://github.com/OWASP/java-html-sanitizer/blob/main/src/main/java/org/owasp/html/Sanitizers.java), [DOCS](https://www.javadoc.io/doc/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/20160628.1/org/owasp/html/Sanitizers.html)].
+        Inbuilt policy is defined in the Sanitizers class available at [[GitHub](https://github.com/OWASP/java-html-sanitizer/blob/main/owasp-java-html-sanitizer/src/main/java/org/owasp/html/Sanitizers.java), [DOCS](https://www.javadoc.io/doc/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/latest/org/owasp/html/Sanitizers.html)].
         ```json
         {
          "type": "inbuilt",
@@ -83,7 +83,7 @@ Thus, each element in the JSON array represents one policy.
         }
         ```     
        
-       In most cases, only using **allow** will do the job. **methods** can be used for more advanced configuration. The list of methods are part of HtmlPolicyBuilder available at [[GitHub](https://github.com/OWASP/java-html-sanitizer/blob/main/src/main/java/org/owasp/html/HtmlPolicyBuilder.java), [DOCS](https://www.javadoc.io/doc/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/20160628.1/org/owasp/html/HtmlPolicyBuilder.html)]
+       In most cases, only using **allow** will do the job. **methods** can be used for more advanced configuration. The list of methods are part of HtmlPolicyBuilder available at [[GitHub](https://github.com/OWASP/java-html-sanitizer/blob/main/owasp-java-html-sanitizer/src/main/java/org/owasp/html/HtmlPolicyBuilder.java), [DOCS](https://www.javadoc.io/doc/com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/latest/org/owasp/html/HtmlPolicyBuilder.html)]
        
        **Note:** Supports method with String parameters or no parametes and return type as being HtmlPolicyBuilder and AttributeBuilder as defined in the docs.
 


### PR DESCRIPTION
Sanitizers and HtmlPolicyBuilder have been moved under `owasp-java-html-sanitizer` directory. Thus, the original links doesn't work anymore.

Also, the documents of them are updated into latest ones.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
